### PR TITLE
Fix badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fastlane-plugin-clubmate `fastlane` Plugin
 
-[![fastlane Plugin Badge](https://raw.githubusercontent.com/fastlane/fastlane/master/fastlane/assets/plugin-badge.svg)](https://rubygems.org/gems/fastlane-plugin-clubmate)
+[![fastlane Plugin Badge](https://rawcdn.githack.com/fastlane/fastlane/master/fastlane/assets/plugin-badge.svg)](https://rubygems.org/gems/fastlane-plugin-clubmate)
 
 ## Getting Started
 


### PR DESCRIPTION
Proxying the request through https://raw.githack.com/ allows the content to be served up with the correct content-type to be rendered as a SVG image.

Another alternative is to put this file on a different host we control, possibly https://fastlane.tools
